### PR TITLE
Added documentation clarification

### DIFF
--- a/src/Halogen/Subscription.purs
+++ b/src/Halogen/Subscription.purs
@@ -147,7 +147,8 @@ derive newtype instance semigroupSubscription :: Semigroup Subscription
 derive newtype instance monoidSubscription :: Monoid Subscription
 
 -- | Subscribe to an `Emitter` by providing a callback to run on values produced
--- | by the emitter:
+-- | by the emitter. Not to be confused with the `subscribe` function from the
+-- | regular `Halogen` module!
 -- |
 -- | ```purs
 -- | -- Produce an emitter / listener pair with `create`:


### PR DESCRIPTION
Added a sentence to prevent confusion between two similarly-named functions.

**Description of the change**
Just a small clarification in the documentation. I got confused for more time than I should have trying to follow https://purescript-halogen.github.io/purescript-halogen/guide/04-Lifecycles-Subscriptions.html only to realize that the tutorial's `subscribe` function was not the one imported from this package. I learned on the purescript discord that I was not the only one to have had that problem.

None of the items in the checklist below are checked, because this is just a small documentation addition, so I believe none is applicable here.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
